### PR TITLE
Update source trace syntax

### DIFF
--- a/examples/example_source_files/file.py
+++ b/examples/example_source_files/file.py
@@ -2,7 +2,7 @@ def hello_world():
     print("hello world")
 
 
-# @sdoc[REQ-002]
+# @relation(REQ-002, scope=range_start)
 def hello_world_2():
     print("hello world")
-# @sdoc[/REQ-002]
+# @relation(REQ-002, scope=range_end)

--- a/examples/example_source_files/file2.py
+++ b/examples/example_source_files/file2.py
@@ -3,7 +3,7 @@ def hello_world():
     print("hello world")
 
 
-# @sdoc[REQ-003]
+# @relation(REQ-003, scope=range_start)
 def hello_world_3():
     print("hello world")
-# @sdoc[/REQ-003]
+# @relation(REQ-003, scope=range_end)


### PR DESCRIPTION
Use the recommended `@relation` syntax rather than `@sdoc` for source trace annotations.